### PR TITLE
Add internal serializer for dot snapshot

### DIFF
--- a/src/__test__/__snapshots__/index.spec.ts.snap
+++ b/src/__test__/__snapshots__/index.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`public api toBeValidDotAndMatchSnapshot 1`] = `"digraph g { a -> b; }"`;
+exports[`public api toBeValidDotAndMatchSnapshot 1`] = `digraph g { a -> b; }`;
 
 exports[`public api toMatchDotJsonSnapshot 1`] = `
 Object {

--- a/src/__test__/__snapshots__/to-be-valid-dot-and-match-snapshot.spec.ts.snap
+++ b/src/__test__/__snapshots__/to-be-valid-dot-and-match-snapshot.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toBeValidDotAndMatchSnapshot test matcher works 1`] = `"digraph g { a -> b; }"`;
+exports[`toBeValidDotAndMatchSnapshot test matcher works 1`] = `digraph g { a -> b; }`;

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,0 +1,24 @@
+const raw = Symbol();
+
+interface IWrapper {
+  [raw]: string;
+}
+
+function test(something: any): something is IWrapper {
+  return something && typeof something[raw] === 'string';
+}
+
+function print(wrapper: IWrapper): string {
+  return wrapper[raw];
+}
+
+export function wrap(value: string): IWrapper {
+  return { [raw]: value };
+}
+
+export const SnapshotSerializer: jest.SnapshotSerializerPlugin = {
+  test,
+  print,
+};
+
+expect.addSnapshotSerializer(SnapshotSerializer);

--- a/src/to-be-valid-dot-and-match-snapshot.ts
+++ b/src/to-be-valid-dot-and-match-snapshot.ts
@@ -1,10 +1,11 @@
 import { toMatchSnapshot } from 'jest-snapshot';
 import { isValidDot } from './lib/is-valid-dot';
+import { wrap } from './serializer';
 
 export function toBeValidDotAndMatchSnapshotMatcher(this: any, dot: string): jest.CustomMatcherResult {
   const result = isValidDot(dot);
   if (result.pass) {
-    return toMatchSnapshot.call(this, dot);
+    return toMatchSnapshot.call(this, wrap(dot));
   }
   return result;
 }


### PR DESCRIPTION
# **HAS BRAKING CHANGE**

## What was a problem

When taking a DOT snapshot with the toBeValidDotAndMatchSnapshot API, it was treated as a string and the string was escaped, making the snapshot difficult to read.

## How this PR fixes the problem

Created a serializer to avoid escaping strings.

### Snapshot Diff

```diff
- exports[`public api toBeValidDotAndMatchSnapshot 1`] = `"digraph g { a -> b; }"`;
+ exports[`public api toBeValidDotAndMatchSnapshot 1`] = `digraph g { a -> b; }`;
```
